### PR TITLE
From To dates widget

### DIFF
--- a/app/components/dates/index.gts
+++ b/app/components/dates/index.gts
@@ -1,0 +1,59 @@
+import Component from '@glimmer/component';
+import { Input } from '@frontile/forms';
+import { t } from 'ember-intl';
+import { inject as service } from '@ember/service';
+import type SettingsService from 'the-mountains-are-calling/services/settings';
+import set from 'ember-set-helper/helpers/set';
+import { hash } from '@ember/helper';
+
+interface DatesSignature {
+  Args: {};
+  Element: HTMLDivElement;
+}
+
+// eslint-disable-next-line ember/no-empty-glimmer-component-classes
+export default class Dates extends Component<DatesSignature> {
+  @service declare settings: SettingsService;
+
+  <template>
+    {{#if this.settings.hasOneDaySelection}}
+      {{! template-lint-disable no-unknown-arguments-for-builtin-components require-input-label }}
+      <Input
+        @value={{this.settings.dateFromShort}}
+        @type='date'
+        name='date'
+        @label={{t 'settings.date.label'}}
+        @description={{t 'settings.date.description'}}
+        @onChange={{set this.settings 'date'}}
+        @classes={{hash base='flex-1'}}
+      />
+    {{else}}
+      {{! template-lint-disable no-unknown-arguments-for-builtin-components require-input-label }}
+      <Input
+        @value={{this.settings.dateFromShort}}
+        @type='date'
+        name='dateFrom'
+        @label={{t 'settings.date-from.label'}}
+        @description={{t 'settings.date-from.description'}}
+        @onChange={{set this.settings 'dateFrom'}}
+        @classes={{hash base='w-1/2'}}
+      />
+      {{! template-lint-disable no-unknown-arguments-for-builtin-components require-input-label }}
+      <Input
+        @value={{this.settings.dateToShort}}
+        @type='date'
+        name='dateTo'
+        @label={{t 'settings.date-to.label'}}
+        @description={{t 'settings.date-to.description'}}
+        @onChange={{set this.settings 'dateTo'}}
+        @classes={{hash base='w-1/2'}}
+      />
+    {{/if}}
+  </template>
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    Dates: typeof Dates;
+  }
+}

--- a/app/components/map/date-selector.gts
+++ b/app/components/map/date-selector.gts
@@ -4,14 +4,10 @@ import { inject as service } from '@ember/service';
 import type SettingsService from 'the-mountains-are-calling/services/settings';
 import { fn, hash } from '@ember/helper';
 import { Input } from '@frontile/forms';
-//@ts-expect-error No TS yet
-import SunCalc from 'suncalc';
 import { on } from '@ember/modifier';
 //@ts-ignore No TS stuff yet
 import HeroIcon from 'ember-heroicons/components/hero-icon';
-import { action } from '@ember/object';
-import type { Point } from 'the-mountains-are-calling/services/settings';
-import set from 'ember-set-helper/helpers/set';
+import Dates from '../dates';
 
 interface DateSelectorSignature {
   Args: {};
@@ -22,40 +18,21 @@ export default class DateSelector extends Component<DateSelectorSignature> {
   @service declare settings: SettingsService;
 
   <template>
-    <div class='flex flex-row gap-4'>
+    <div class='flex flex-row gap-4 items-end'>
       <Button
         {{on 'click' (fn this.settings.addDays -1)}}
         @appearance='outlined'
+        @size='lg'
       >
         <HeroIcon class='h-4' @icon='chevron-left' />
       </Button>
-      {{#if this.settings.hasOneDaySelection}}
-        {{! template-lint-disable no-unknown-arguments-for-builtin-components require-input-label }}
-        <Input
-          @value={{this.settings.dateShort}}
-          @type='date'
-          @classes={{hash base='flex-1'}}
-          @onChange={{set this.settings 'date'}}
-        />
-      {{else}}
-        {{! template-lint-disable no-unknown-arguments-for-builtin-components require-input-label }}
-        <Input
-          @value={{this.settings.dateShort}}
-          @type='date'
-          @classes={{hash base='w-1/2'}}
-          @onChange={{set this.settings 'date'}}
-        />
-        {{! template-lint-disable no-unknown-arguments-for-builtin-components require-input-label }}
-        <Input
-          @value={{this.settings.dateShort}}
-          @type='date'
-          @classes={{hash base='w-1/2'}}
-          @onChange={{set this.settings 'date'}}
-        />
-      {{/if}}
+
+      <Dates />
+
       <Button
         {{on 'click' (fn this.settings.addDays 1)}}
         @appearance='outlined'
+        @size='lg'
       >
         <HeroIcon class='h-4' @icon='chevron-right' />
       </Button>

--- a/app/components/map/date-selector.gts
+++ b/app/components/map/date-selector.gts
@@ -2,8 +2,7 @@ import Component from '@glimmer/component';
 import { Button } from '@frontile/buttons';
 import { inject as service } from '@ember/service';
 import type SettingsService from 'the-mountains-are-calling/services/settings';
-import { fn, hash } from '@ember/helper';
-import { Input } from '@frontile/forms';
+import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 //@ts-ignore No TS stuff yet
 import HeroIcon from 'ember-heroicons/components/hero-icon';

--- a/app/components/map/date-selector.gts
+++ b/app/components/map/date-selector.gts
@@ -1,0 +1,70 @@
+import Component from '@glimmer/component';
+import { Button } from '@frontile/buttons';
+import { inject as service } from '@ember/service';
+import type SettingsService from 'the-mountains-are-calling/services/settings';
+import { fn, hash } from '@ember/helper';
+import { Input } from '@frontile/forms';
+//@ts-expect-error No TS yet
+import SunCalc from 'suncalc';
+import { on } from '@ember/modifier';
+//@ts-ignore No TS stuff yet
+import HeroIcon from 'ember-heroicons/components/hero-icon';
+import { action } from '@ember/object';
+import type { Point } from 'the-mountains-are-calling/services/settings';
+import set from 'ember-set-helper/helpers/set';
+
+interface DateSelectorSignature {
+  Args: {};
+  Element: HTMLDivElement;
+}
+
+export default class DateSelector extends Component<DateSelectorSignature> {
+  @service declare settings: SettingsService;
+
+  <template>
+    <div class='flex flex-row gap-4'>
+      <Button
+        {{on 'click' (fn this.settings.addDays -1)}}
+        @appearance='outlined'
+      >
+        <HeroIcon class='h-4' @icon='chevron-left' />
+      </Button>
+      {{#if this.settings.hasOneDaySelection}}
+        {{! template-lint-disable no-unknown-arguments-for-builtin-components require-input-label }}
+        <Input
+          @value={{this.settings.dateShort}}
+          @type='date'
+          @classes={{hash base='flex-1'}}
+          @onChange={{set this.settings 'date'}}
+        />
+      {{else}}
+        {{! template-lint-disable no-unknown-arguments-for-builtin-components require-input-label }}
+        <Input
+          @value={{this.settings.dateShort}}
+          @type='date'
+          @classes={{hash base='w-1/2'}}
+          @onChange={{set this.settings 'date'}}
+        />
+        {{! template-lint-disable no-unknown-arguments-for-builtin-components require-input-label }}
+        <Input
+          @value={{this.settings.dateShort}}
+          @type='date'
+          @classes={{hash base='w-1/2'}}
+          @onChange={{set this.settings 'date'}}
+        />
+      {{/if}}
+      <Button
+        {{on 'click' (fn this.settings.addDays 1)}}
+        @appearance='outlined'
+      >
+        <HeroIcon class='h-4' @icon='chevron-right' />
+      </Button>
+    </div>
+  </template>
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    DateSelector: typeof DateSelector;
+  }
+}

--- a/app/components/map/filter.gts
+++ b/app/components/map/filter.gts
@@ -20,7 +20,7 @@ export default class Filter extends Component<MapFilterSignature> {
 
   get points() {
     const dayStart = this.settings.dateFrom.valueOf() / 1000;
-    const dayEnd = this.settings.dateFrom.endOf('day').valueOf() / 1000;
+    const dayEnd = this.settings.dateTo.valueOf() / 1000;
 
     return Object.values(this.args.data || {}).filter((elm) => {
       return elm.timestamp > dayStart && elm.timestamp < dayEnd;

--- a/app/components/map/filter.gts
+++ b/app/components/map/filter.gts
@@ -19,8 +19,8 @@ export default class Filter extends Component<MapFilterSignature> {
   @service declare settings: SettingsService;
 
   get points() {
-    const dayStart = this.settings.date.valueOf() / 1000;
-    const dayEnd = this.settings.date.endOf('day').valueOf() / 1000;
+    const dayStart = this.settings.dateFrom.valueOf() / 1000;
+    const dayEnd = this.settings.dateFrom.endOf('day').valueOf() / 1000;
 
     return Object.values(this.args.data || {}).filter((elm) => {
       return elm.timestamp > dayStart && elm.timestamp < dayEnd;

--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -4,7 +4,6 @@ import { service } from '@ember/service';
 import { Request } from '@warp-drive/ember';
 // @ts-expect-error No TS stuff yet
 import LeafletMap from 'ember-leaflet/components/leaflet-map';
-import MapForm from './form';
 import Filter from './filter';
 import Color from 'colorjs.io';
 import L, { LatLngBounds, Point } from 'leaflet';
@@ -15,6 +14,8 @@ import timestampToHuman from 'the-mountains-are-calling/helpers/timestamp-to-hum
 import { firebaseQuery } from 'the-mountains-are-calling/builders/firebase';
 //@ts-ignore HeroIcon nope
 import HeroIcon from 'ember-heroicons/components/hero-icon';
+import DateSelector from './date-selector';
+import PointSelector from './point-selector';
 
 interface Signature {
   Args: {};
@@ -54,7 +55,10 @@ export default class Map extends Component<Signature> {
 
       <:content as |result|>
         <Filter @data={{result}} as |filtered|>
-          <MapForm @data={{filtered.points}} />
+          <div class='flex flex-col gap-2 pb-2'>
+            <DateSelector />
+            <PointSelector @data={{filtered.points}} />
+          </div>
 
           {{#if (isEmpty filtered.points)}}
             <div class='w-full py-32 flex justify-center items-center'>

--- a/app/components/map/point-selector.gts
+++ b/app/components/map/point-selector.gts
@@ -1,21 +1,16 @@
 import Component from '@glimmer/component';
 import timestampToTime from 'the-mountains-are-calling/helpers/timestamp-to-time';
-import { Button } from '@frontile/buttons';
 import { inject as service } from '@ember/service';
 import type SettingsService from 'the-mountains-are-calling/services/settings';
 import { fn, hash } from '@ember/helper';
-import { Input } from '@frontile/forms';
 //@ts-expect-error No TS yet
 import SunCalc from 'suncalc';
-import { on } from '@ember/modifier';
 //@ts-ignore No TS stuff yet
-import HeroIcon from 'ember-heroicons/components/hero-icon';
 import { action } from '@ember/object';
 //@ts-expect-error No TS yet
 import didIntersect from 'ember-scroll-modifiers/modifiers/did-intersect';
 import type { Point } from 'the-mountains-are-calling/services/settings';
 import { t } from 'ember-intl';
-import set from 'ember-set-helper/helpers/set';
 
 interface PointSelectorSignature {
   Args: {

--- a/app/components/map/point-selector.gts
+++ b/app/components/map/point-selector.gts
@@ -90,6 +90,6 @@ export default class PointSelector extends Component<PointSelectorSignature> {
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {
-    MapForm: typeof PointSelector;
+    PointSelector: typeof PointSelector;
   }
 }

--- a/app/components/map/point-selector.gts
+++ b/app/components/map/point-selector.gts
@@ -17,7 +17,7 @@ import type { Point } from 'the-mountains-are-calling/services/settings';
 import { t } from 'ember-intl';
 import set from 'ember-set-helper/helpers/set';
 
-interface MapFormSignature {
+interface PointSelectorSignature {
   Args: {
     data: any[];
   };
@@ -46,7 +46,7 @@ function getSunColor(timestamp: number, latitude: number, longitude: number) {
   return COLORS[i];
 }
 
-export default class MapForm extends Component<MapFormSignature> {
+export default class PointSelector extends Component<PointSelectorSignature> {
   @service declare settings: SettingsService;
 
   @action onEnter(point: Point) {
@@ -54,30 +54,8 @@ export default class MapForm extends Component<MapFormSignature> {
   }
 
   <template>
-    <div class='flex flex-row gap-4'>
-      <Button
-        {{on 'click' (fn this.settings.addDays -1)}}
-        @appearance='outlined'
-      >
-        <HeroIcon class='h-4' @icon='chevron-left' />
-      </Button>
-      {{! template-lint-disable no-unknown-arguments-for-builtin-components require-input-label }}
-      <Input
-        @value={{this.settings.dateShort}}
-        @type='date'
-        @classes={{hash base='flex-1'}}
-        @onChange={{set this.settings 'date'}}
-      />
-      <Button
-        {{on 'click' (fn this.settings.addDays 1)}}
-        @appearance='outlined'
-      >
-        <HeroIcon class='h-4' @icon='chevron-right' />
-      </Button>
-    </div>
-
     <div
-      class='grid [grid-template-areas:"stack"] justify-items-center items-start py-2'
+      class='grid [grid-template-areas:"stack"] justify-items-center items-start'
     >
       <div
         class='w-24 pt-2 border border-gray-400 rounded [grid-area:stack] text-center h-full'
@@ -112,6 +90,6 @@ export default class MapForm extends Component<MapFormSignature> {
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {
-    MapForm: typeof MapForm;
+    MapForm: typeof PointSelector;
   }
 }

--- a/app/components/settings.gts
+++ b/app/components/settings.gts
@@ -44,6 +44,14 @@ export default class Settings extends Component<SettingsSignature> {
         @description={{t 'settings.is-accuracy-visible.description'}}
         @onChange={{set this.settings 'isAccuracyVisible'}}
       />
+
+      <Checkbox
+        @checked={{this.settings.hasOneDaySelection}}
+        name='hasOneDaySelection'
+        @label={{t 'settings.has-one-day-selection.label'}}
+        @description={{t 'settings.has-one-day-selection.description'}}
+        @onChange={{set this.settings 'hasOneDaySelection'}}
+      />
     </div>
   </template>
 }

--- a/app/components/settings/index.gts
+++ b/app/components/settings/index.gts
@@ -5,6 +5,7 @@ import { t } from 'ember-intl';
 import { inject as service } from '@ember/service';
 import type SettingsService from 'the-mountains-are-calling/services/settings';
 import set from 'ember-set-helper/helpers/set';
+import Dates from '../dates';
 
 interface SettingsSignature {
   Args: {};
@@ -16,7 +17,7 @@ export default class Settings extends Component<SettingsSignature> {
   @service declare settings: SettingsService;
 
   <template>
-    <div class='grid grid-cols-1 sm:grid-cols-2 w-full gap-4 py-4'>
+    <div class='flex flex-col w-full md:w-1/2 gap-4 py-4'>
       {{! template-lint-disable no-unknown-arguments-for-builtin-components require-input-label }}
       <Input
         @value={{this.settings.deviceId}}
@@ -27,14 +28,14 @@ export default class Settings extends Component<SettingsSignature> {
         @onChange={{set this.settings 'deviceId'}}
       />
 
-      {{! template-lint-disable no-unknown-arguments-for-builtin-components require-input-label }}
-      <Input
-        @value={{this.settings.dateShort}}
-        @type='date'
-        name='date'
-        @label={{t 'settings.date.label'}}
-        @description={{t 'settings.date.description'}}
-        @onChange={{set this.settings 'date'}}
+      <Dates />
+
+      <Checkbox
+        @checked={{this.settings.hasOneDaySelection}}
+        name='hasOneDaySelection'
+        @label={{t 'settings.has-one-day-selection.label'}}
+        @description={{t 'settings.has-one-day-selection.description'}}
+        @onChange={{set this.settings 'hasOneDaySelection'}}
       />
 
       <Checkbox
@@ -43,14 +44,6 @@ export default class Settings extends Component<SettingsSignature> {
         @label={{t 'settings.is-accuracy-visible.label'}}
         @description={{t 'settings.is-accuracy-visible.description'}}
         @onChange={{set this.settings 'isAccuracyVisible'}}
-      />
-
-      <Checkbox
-        @checked={{this.settings.hasOneDaySelection}}
-        name='hasOneDaySelection'
-        @label={{t 'settings.has-one-day-selection.label'}}
-        @description={{t 'settings.has-one-day-selection.description'}}
-        @onChange={{set this.settings 'hasOneDaySelection'}}
       />
     </div>
   </template>

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -20,10 +20,10 @@ export default class SettingsService extends Service {
   })
   declare _date: string;
 
-  get date(): dayjs.Dayjs {
+  get dateFrom(): dayjs.Dayjs {
     return dayjs(this._date);
   }
-  set date(newDate: string | dayjs.Dayjs) {
+  set dateFrom(newDate: string | dayjs.Dayjs) {
     if (typeof newDate === 'string') {
       // dayjs gives _current_ date _only_ for `dayjs(undefined)`, no `dayjs(null)`
       this._date = dayjs(newDate || undefined)
@@ -35,12 +35,12 @@ export default class SettingsService extends Service {
   }
 
   get dateShort() {
-    return dayjs(this.date).format('YYYY-MM-DD');
+    return dayjs(this.dateFrom).format('YYYY-MM-DD');
   }
 
   @action
   addDays(amount: number) {
-    this.date = this.date.add(amount, 'days');
+    this.dateFrom = this.dateFrom.add(amount, 'days');
   }
 
   // ===== .deviceId =====

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -13,7 +13,7 @@ export interface Point {
 }
 
 export default class SettingsService extends Service {
-  // .date
+  // ===== .date =====
   @trackedInLocalStorage({
     keyName: 'date',
     defaultValue: dayjs().startOf('day').toISOString(),
@@ -25,7 +25,7 @@ export default class SettingsService extends Service {
   }
   set date(newDate: string | dayjs.Dayjs) {
     if (typeof newDate === 'string') {
-      // dayjs gives _current_ date _only_ for `dayjs(undefined)
+      // dayjs gives _current_ date _only_ for `dayjs(undefined)`, no `dayjs(null)`
       this._date = dayjs(newDate || undefined)
         .startOf('day')
         .toISOString();
@@ -43,7 +43,7 @@ export default class SettingsService extends Service {
     this.date = this.date.add(amount, 'days');
   }
 
-  // .deviceId
+  // ===== .deviceId =====
   @trackedInLocalStorage({ keyName: 'deviceId', defaultValue: 'demo' })
   declare _deviceId: string;
   get deviceId() {
@@ -53,10 +53,10 @@ export default class SettingsService extends Service {
     this._deviceId = newDeviceId;
   }
 
-  // .highlightedPoint
+  // ===== .highlightedPoint =====
   @tracked highlightedPoint: Point | undefined;
 
-  // .isAccuracyVisible
+  // ===== .isAccuracyVisible =====
   @trackedInLocalStorage({ keyName: 'isAccuracyVisible', defaultValue: true })
   declare _isAccuracyVisible: string;
   get isAccuracyVisible() {
@@ -64,6 +64,16 @@ export default class SettingsService extends Service {
   }
   set isAccuracyVisible(newValue: boolean) {
     this._isAccuracyVisible = Boolean(newValue).toString();
+  }
+
+  // ===== .hasOneDaySelection =====
+  @trackedInLocalStorage({ keyName: 'hasOneDaySelection', defaultValue: true })
+  declare _hasOneDaySelection: string;
+  get hasOneDaySelection() {
+    return this._hasOneDaySelection === 'true';
+  }
+  set hasOneDaySelection(newValue: boolean) {
+    this._hasOneDaySelection = Boolean(newValue).toString();
   }
 }
 

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -13,34 +13,73 @@ export interface Point {
 }
 
 export default class SettingsService extends Service {
-  // ===== .date =====
+  // ===== .dateFrom =====
   @trackedInLocalStorage({
-    keyName: 'date',
+    keyName: 'dateFrom',
     defaultValue: dayjs().startOf('day').toISOString(),
   })
-  declare _date: string;
+  declare _dateFrom: string;
 
   get dateFrom(): dayjs.Dayjs {
-    return dayjs(this._date);
+    return dayjs(this._dateFrom);
   }
   set dateFrom(newDate: string | dayjs.Dayjs) {
     if (typeof newDate === 'string') {
       // dayjs gives _current_ date _only_ for `dayjs(undefined)`, no `dayjs(null)`
-      this._date = dayjs(newDate || undefined)
+      this._dateFrom = dayjs(newDate || undefined)
         .startOf('day')
         .toISOString();
     } else {
-      this._date = newDate.startOf('day').toISOString();
+      this._dateFrom = newDate.startOf('day').toISOString();
     }
   }
 
-  get dateShort() {
+  get dateFromShort() {
     return dayjs(this.dateFrom).format('YYYY-MM-DD');
   }
 
+  // ===== .dateTo =====
+  @trackedInLocalStorage({
+    keyName: 'dateTo',
+    defaultValue: dayjs().add(1, 'day').startOf('day').toISOString(),
+  })
+  declare _dateTo: string;
+
+  get dateTo(): dayjs.Dayjs {
+    return dayjs(this._dateTo);
+  }
+  set dateTo(newDate: string | dayjs.Dayjs) {
+    if (typeof newDate === 'string') {
+      // dayjs gives _current_ date _only_ for `dayjs(undefined)`, no `dayjs(null)`
+      this._dateTo = dayjs(newDate || undefined)
+        .startOf('day')
+        .toISOString();
+    } else {
+      this._dateTo = newDate.startOf('day').toISOString();
+    }
+  }
+
+  get dateToShort() {
+    return dayjs(this.dateTo).format('YYYY-MM-DD');
+  }
+
+  // ===== .date ======
+  // Getter is shorthand for dateFrom
+  // Setter will set dateFrom to current value and dateTo to +1 day
+  get date() {
+    return this.dateFrom;
+  }
+  set date(newDate: string | dayjs.Dayjs) {
+    const value = dayjs(newDate);
+    this.dateFrom = value;
+    this.dateTo = value.add(1, 'day').startOf('day');
+  }
+
+  // ===== .addDays() =====
   @action
   addDays(amount: number) {
     this.dateFrom = this.dateFrom.add(amount, 'days');
+    this.dateTo = this.dateTo.add(amount, 'days');
   }
 
   // ===== .deviceId =====

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -112,6 +112,10 @@ export default class SettingsService extends Service {
     return this._hasOneDaySelection === 'true';
   }
   set hasOneDaySelection(newValue: boolean) {
+    // When we're going to "one day seleciton" we need to sync from&to dates
+    if (newValue === true) {
+      this.date = this.dateFrom;
+    }
     this._hasOneDaySelection = Boolean(newValue).toString();
   }
 }

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -10,6 +10,9 @@ settings:
   is-accuracy-visible:
     label: Show accuracy
     description: Circle of uncertanity around given position
+  has-one-day-selection:
+    label: Simple date selector
+    description: Select given day, instead of a from-to pair
 map:
   highlighted:
     label: ⏰

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1,9 +1,15 @@
 project:
   name: The Mountains Are Calling
 settings:
+  date-from:
+    label: From
+    description: Start date
+  date-to:
+    label: To
+    description: End date
   date:
     label: Date
-    description: Date to examine
+    description: Exact day
   device-id:
     label: Device ID
     description: Do not share it


### PR DESCRIPTION
- Refactored date selection so it's not assuming the end date is `date + 1 day`
- Created a date selection widget that can select date span & current date (with assumption of +1 day end date)
- Fixes #12 