### PR TITLE
feat: Nicer time picker

### DIFF
--- a/app/components/loader/index.gts
+++ b/app/components/loader/index.gts
@@ -27,7 +27,6 @@ export default class Loader extends Component<Signature> {
   @service declare settings: SettingsService;
 
   get request() {
-    console.log('re-firing request');
     return this.mountainsStore.request(
       firebaseQuery(
         this.settings.deviceUrl,

--- a/app/components/map/filter.gts
+++ b/app/components/map/filter.gts
@@ -22,8 +22,6 @@ export default class Filter extends Component<MapFilterSignature> {
     const dayStart = this.settings.dateFrom.valueOf() / 1000;
     const dayEnd = this.settings.dateTo.valueOf() / 1000;
 
-    console.log(this.args.data);
-
     // TODO: make it so it's not .data.data
     return this.args.data.data.filter((elm) => {
       return elm.timestamp > dayStart && elm.timestamp < dayEnd;

--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -67,7 +67,7 @@ export default class Map extends Component<Signature> {
 
   pickHighlightedPin(
     points: Pin[],
-    highlightedPinTimestamp: number,
+    highlightedPinTimestamp: number | undefined,
   ): Pin | undefined {
     return points.find((p) => p.timestamp === highlightedPinTimestamp);
   }
@@ -78,7 +78,6 @@ export default class Map extends Component<Signature> {
 
   <template>
     <Loader as |l|>
-      {{log l}}
       <Filter @data={{l.result}} as |filtered|>
         <div class='flex flex-col gap-2 pb-2'>
           <DateSelector />

--- a/app/components/map/point-selector.gts
+++ b/app/components/map/point-selector.gts
@@ -70,9 +70,14 @@ export default class PointSelector extends Component<PointSelectorSignature> {
     <div
       class='grid [grid-template-areas:"stack"] justify-items-center items-start'
     >
+      <div class='w-24 pb-4 [grid-area:stack] h-full'>
+        <div class='border-2 border-gray-400 rounded h-full w-full'>
+          {{! The peeking window has to live here in the DOM, otherwise it would overlay the scroll area and hinder scrolling}}
+        </div>
+      </div>
 
       <div
-        class='overflow-x-scroll snap-x py-2 w-full [grid-area:stack] flex flex-row gap-x-4'
+        class='overflow-x-scroll snap-x pt-2 pb-6 w-full [grid-area:stack] flex flex-row gap-x-4'
         {{on 'scrollend' (fn this.onScrollEnd)}}
       >
         <div><div class='[width:50vw] text-right'></div></div>
@@ -105,10 +110,6 @@ export default class PointSelector extends Component<PointSelectorSignature> {
 
       </div>
 
-      <div
-        class='w-24 border-x-2 border-y-2 border-gray-400 rounded [grid-area:stack] h-full'
-      >
-      </div>
     </div>
   </template>
 }

--- a/app/components/map/point-selector.gts
+++ b/app/components/map/point-selector.gts
@@ -52,18 +52,18 @@ function getSunColor(timestamp: number, latitude: number, longitude: number) {
 export default class PointSelector extends Component<PointSelectorSignature> {
   @service declare settings: SettingsService;
 
-  @tracked intersectedPin: Pin | undefined = undefined;
+  // @tracked intersectedPin: Pin | undefined = undefined;
 
-  @action updateHighlightedPin(pin: Pin | undefined) {
-    this.settings.highlightedPin = pin?.timestamp;
+  @action updateHighlightedPin(timestamp: number | undefined) {
+    this.settings.rememberedPin = timestamp;
   }
 
   @action onIntersect(pin: Pin) {
-    this.intersectedPin = pin;
+    this.settings.highlightedPin = pin.timestamp;
   }
 
   @action onScrollEnd() {
-    this.updateHighlightedPin(this.intersectedPin);
+    this.updateHighlightedPin(this.settings.highlightedPin);
   }
 
   <template>
@@ -86,9 +86,9 @@ export default class PointSelector extends Component<PointSelectorSignature> {
           {{#each @data as |point|}}
             <g.ToggleButton
               @isSelected={{eq point.timestamp this.settings.highlightedPin}}
-              @onChange={{fn this.updateHighlightedPin point}}
+              @onChange={{fn this.updateHighlightedPin point.timestamp}}
               {{scrollIntoView
-                shouldScroll=(eq point.timestamp this.settings.highlightedPin)
+                shouldScroll=(eq point.timestamp this.settings.rememberedPin)
                 options=(hash behavior='smooth' inline='center')
               }}
               {{didIntersect

--- a/app/controllers/index.ts
+++ b/app/controllers/index.ts
@@ -7,11 +7,11 @@ export default class IndexController extends Controller {
     {
       dateFrom: { type: 'string' as const },
       dateTo: { type: 'string' as const },
-      highlightedPin: { type: 'string' as const },
+      rememberedPin: { type: 'string' as const },
     },
   ];
 
   @tracked dateFrom = '';
   @tracked dateTo = '';
-  @tracked highlightedPin = '';
+  @tracked rememberedPin = '';
 }

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -37,17 +37,20 @@ export default class SettingsService extends Service {
     return DEMO_DATE_TO;
   }
 
-  // ===== .highlightedPoint =====
-  get highlightedPin(): number | undefined {
-    return Number.parseFloat(this.qp['highlightedPin'] as string);
+  // ===== .rememberedPin =====
+  // This one exists to persist selected pin to QP
+  get rememberedPin(): number | undefined {
+    return Number.parseFloat(this.qp['rememberedPin'] as string);
   }
-  set highlightedPin(newPin: number | undefined) {
+  set rememberedPin(newPin: number | undefined) {
     this.router.replaceWith({
-      queryParams: { highlightedPin: newPin ? newPin.toString() : undefined },
+      queryParams: { rememberedPin: newPin ? newPin.toString() : undefined },
     });
   }
 
-  // @tracked highlightedPin = 0;
+  // ===== .highlightedPin =====
+  // This one exists to highlight given pin directly in the app
+  @tracked highlightedPin: number | undefined = undefined;
 
   // ===== .dateFrom =====
   get dateFrom(): dayjs.Dayjs {


### PR DESCRIPTION
- Individual points are presented as series of toggle buttons.
- Only one button can be toggled at a time (effectivelly making them a radio buttons).
- Visually the toggled one will always, highlight and scroll into the middle of the screen under the "peeking window" to showcase it's highlighted.
- By manually, horizontally scrolling on the strip of the toggle buttons, the user can also move the desired point into the "peeking window", which will then make it selected.
- As integration detail: To debounce data recalculations, the URL updates _only_ when the strip stops scrolling.